### PR TITLE
Verboser error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ Get the first element from an enumerable, and assert that there is only one elem
 ```
 
 ```
-[].first_and_only!  # =>  0 (Enumerable::FirstAndOnly::LengthNotOne)
+[].first_and_only!  # =>  0 (Enumerable::FirstAndOnly::CountNotOne)
 ```
 
 ```
-[:one, :and_two].first_and_only!  # => 2 (Enumerable::FirstAndOnly::LengthNotOne)
+[:one, :and_two].first_and_only!  # => 2 (Enumerable::FirstAndOnly::CountNotOne)
 ```
 
 ## Why?

--- a/first_and_only.gemspec
+++ b/first_and_only.gemspec
@@ -17,11 +17,11 @@ Get the first element from an enumerable, and assert that there is only one elem
 ```
 
 ```
-[].first_and_only!  # =>  0 (Enumerable::FirstAndOnly::LengthNotOne)
+[].first_and_only!  # =>  0 (Enumerable::FirstAndOnly::CountNotOne)
 ```
 
 ```
-[:one, :and_two].first_and_only!  # => 2 (Enumerable::FirstAndOnly::LengthNotOne)
+[:one, :and_two].first_and_only!  # => 2 (Enumerable::FirstAndOnly::CountNotOne)
 ```
   SUMMARY
   spec.homepage      = "https://github.com/dapplebeforedawn/first-and-only-gem"
@@ -35,5 +35,5 @@ Get the first element from an enumerable, and assert that there is only one elem
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 2.14.1"
-  spec.add_development_dependency "pry-plus"
+  spec.add_development_dependency "pry-byebug"
 end

--- a/lib/first_and_only.rb
+++ b/lib/first_and_only.rb
@@ -2,11 +2,15 @@ require "first_and_only/version"
 
 module Enumerable
   def first_and_only!
-    fail(FirstAndOnly::LengthNotOne, count) if first(2).count != 1
+    fail(FirstAndOnly::CountNotOne.new count) if first(2).count != 1
     first
   end
 
   module FirstAndOnly
-    LengthNotOne = Class.new(StandardError)
+    class CountNotOne < StandardError
+      def initialize(count)
+        super("Expected the count to be 1, but it was #{count}.")
+      end
+    end
   end
 end

--- a/spec/first_and_only_spec.rb
+++ b/spec/first_and_only_spec.rb
@@ -8,8 +8,10 @@ describe "Enumerable#first_and_only!" do
 
   shared_examples_for "it_is_empty" do
     specify do
-      expect { subject.first_and_only! }.to \
-        raise_error(Enumerable::FirstAndOnly::LengthNotOne, "0")
+      expect { subject.first_and_only! }.to raise_error(
+        Enumerable::FirstAndOnly::CountNotOne,
+        "Expected the count to be 1, but it was 0."
+      )
     end
   end
 
@@ -17,8 +19,10 @@ describe "Enumerable#first_and_only!" do
     specify do
       fail "bad example" if subject.count < 2
 
-      expect { subject.first_and_only! }.to \
-        raise_error(Enumerable::FirstAndOnly::LengthNotOne, subject.count.to_s)
+      expect { subject.first_and_only! }.to raise_error(
+        Enumerable::FirstAndOnly::CountNotOne,
+        "Expected the count to be 1, but it was #{subject.count}."
+      )
     end
   end
 


### PR DESCRIPTION
Spell out the problem in the error message for user-friendliness.

Motivation: When this error is raised while Rails is rendering a view, Rails helpfully rescues it and re-raises it as an `ActionView::Template::Error`. So, I was getting just `ActionView::Template::Error: 0`, which is less than helpful.

Also, rename `LengthNotOne` to `CountNotOne` since we use the `count` method and not the `length` method.
