### PR TITLE
Avoid calling count on Enumerable

### DIFF
--- a/lib/first_and_only.rb
+++ b/lib/first_and_only.rb
@@ -2,15 +2,22 @@ require "first_and_only/version"
 
 module Enumerable
   def first_and_only!
-    fail(FirstAndOnly::CountNotOne.new) if first(2).count != 1
-    first
+    case first(2).count
+    when 0
+      fail FirstAndOnly::CountZero, FirstAndOnly::COUNT_ZERO_ERROR_MESSAGE
+    when 1
+      first
+    else
+      fail FirstAndOnly::CountGreaterThanOne, FirstAndOnly::COUNT_GREATER_THAN_ONE_ERROR_MESSAGE
+    end
   end
 
   module FirstAndOnly
-    class CountNotOne < StandardError
-      def initialize
-        super("Expected the count to be 1.")
-      end
-    end
+    CountNotOne = Class.new(StandardError)
+    CountZero = Class.new(CountNotOne)
+    CountGreaterThanOne = Class.new(CountNotOne)
+
+    COUNT_ZERO_ERROR_MESSAGE = 'Expected the count to be 1, was 0.'.freeze
+    COUNT_GREATER_THAN_ONE_ERROR_MESSAGE = 'Expected the count to be 1, was greater than 1.'.freeze
   end
 end

--- a/lib/first_and_only.rb
+++ b/lib/first_and_only.rb
@@ -2,14 +2,14 @@ require "first_and_only/version"
 
 module Enumerable
   def first_and_only!
-    fail(FirstAndOnly::CountNotOne.new count) if first(2).count != 1
+    fail(FirstAndOnly::CountNotOne.new) if first(2).count != 1
     first
   end
 
   module FirstAndOnly
     class CountNotOne < StandardError
-      def initialize(count)
-        super("Expected the count to be 1, but it was #{count}.")
+      def initialize
+        super("Expected the count to be 1.")
       end
     end
   end

--- a/spec/first_and_only_spec.rb
+++ b/spec/first_and_only_spec.rb
@@ -9,8 +9,8 @@ describe "Enumerable#first_and_only!" do
   shared_examples_for "it_is_empty" do
     specify do
       expect { subject.first_and_only! }.to raise_error(
-        Enumerable::FirstAndOnly::CountNotOne,
-        "Expected the count to be 1."
+        Enumerable::FirstAndOnly::CountZero,
+        "Expected the count to be 1, was 0."
       )
     end
   end
@@ -20,8 +20,8 @@ describe "Enumerable#first_and_only!" do
       fail "bad example" if subject.first(2).count < 2
 
       expect { subject.first_and_only! }.to raise_error(
-        Enumerable::FirstAndOnly::CountNotOne,
-        "Expected the count to be 1."
+        Enumerable::FirstAndOnly::CountGreaterThanOne,
+        "Expected the count to be 1, was greater than 1."
       )
     end
   end

--- a/spec/first_and_only_spec.rb
+++ b/spec/first_and_only_spec.rb
@@ -10,18 +10,18 @@ describe "Enumerable#first_and_only!" do
     specify do
       expect { subject.first_and_only! }.to raise_error(
         Enumerable::FirstAndOnly::CountNotOne,
-        "Expected the count to be 1, but it was 0."
+        "Expected the count to be 1."
       )
     end
   end
 
   shared_examples_for "it_has_more_than_one_element" do
     specify do
-      fail "bad example" if subject.count < 2
+      fail "bad example" if subject.first(2).count < 2
 
       expect { subject.first_and_only! }.to raise_error(
         Enumerable::FirstAndOnly::CountNotOne,
-        "Expected the count to be 1, but it was #{subject.count}."
+        "Expected the count to be 1."
       )
     end
   end
@@ -71,6 +71,24 @@ describe "Enumerable#first_and_only!" do
 
     context "with more than on element" do
       subject { my_enumerable.new(:element, :element) }
+      it_behaves_like "it_has_more_than_one_element"
+    end
+
+  end
+
+  describe "infinite enumerable" do
+    let(:infinite_enumerable) do
+      Class.new do
+        include Enumerable
+
+        def each
+          yield(rand(1_000_000)) while true
+        end
+      end
+    end
+
+    context "with more than on element" do
+      subject { infinite_enumerable.new }
       it_behaves_like "it_has_more_than_one_element"
     end
 

--- a/spec/first_and_only_spec.rb
+++ b/spec/first_and_only_spec.rb
@@ -26,6 +26,16 @@ describe "Enumerable#first_and_only!" do
     end
   end
 
+  describe "backwards compatibility with CountNotOne error class" do
+    specify do
+      expect(Enumerable::FirstAndOnly::CountZero).to be < Enumerable::FirstAndOnly::CountNotOne
+    end
+
+    specify do
+      expect(Enumerable::FirstAndOnly::CountGreaterThanOne).to be < Enumerable::FirstAndOnly::CountNotOne
+    end
+  end
+
   describe "an array" do
 
     context "with one element" do


### PR DESCRIPTION
@mikegee we talked about this awhile back so I thought I would put something together. 

There could be `Enumerable` objects where it takes a very long time in order to get a count. `first_and_only` should avoid calling count especially since `first_and_only` only needs to know whether there are 0, 1, or 2 objects to do its job.

@dapplebeforedawn What do you think?
